### PR TITLE
Set putmessage as first to fix timing issues

### DIFF
--- a/src/lib/connection/connection.js
+++ b/src/lib/connection/connection.js
@@ -3,7 +3,7 @@ import fallback from './connector/fallback.js';
 import postMessage from './connector/postmessage.js';
 import putMessage from './connector/putMessage.js';
 let log = require('loglevel');
-let connect = Promise.race([postMessage(), postMessageLegacy(), putMessage(), fallback()]);
+let connect = Promise.race([putMessage(), postMessage(), postMessageLegacy(), fallback()]);
 
 /**
  * Send a message to the App


### PR DESCRIPTION
This PR changes the running order to get the IOS messaging start as early as possible, as there were timing issues. As this is only viable for IOS, on web devices no problems should occur.

To test:

- connection order on all devices should remain as before