### PR TITLE
Pl 526 add fallback to legacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staffbase/plugins-client-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1-beta1",
   "description": "Staffbase plugins client SDK for JavaScript",
   "main": "dist/plugins-client-sdk.js",
   "module": "dist/plugins-client-sdk.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staffbase/plugins-client-sdk",
-  "version": "0.3.1-beta1",
+  "version": "0.3.1-beta2",
   "description": "Staffbase plugins client SDK for JavaScript",
   "main": "dist/plugins-client-sdk.js",
   "module": "dist/plugins-client-sdk.esm.js",

--- a/src/lib/connection/connector/fallback-handlers.js
+++ b/src/lib/connection/connector/fallback-handlers.js
@@ -139,13 +139,17 @@ export function getBranchDefaultLanguage() {
 /**
  * Gets the choosen language from a given content object
  *
- * @param {object|array} content
+ * @param {?object|array} content
  *
  * @return {string}
  */
 export function getPreferredContentLocale(content) {
   log.debug('fallback/getPreferredContentLocale');
   const locale = getBranchDefaultLanguage().locale;
+
+  if (!content) {
+    return locale;
+  }
 
   if (Array.isArray(content)) {
     const index = content.indexOf(locale);

--- a/src/lib/connection/connector/fallback.js
+++ b/src/lib/connection/connector/fallback.js
@@ -45,45 +45,33 @@ export function disconnect() {
  * @return {Promise<any>} which awaits the response of the Staffbase App
  * @throws {Error} on commands not supported by protocol
  */
-async function sendMessage(cmd, ...payload) {
+export async function sendMessage(cmd, ...payload) {
   log.info('fallback/sendMessage ' + cmd);
   log.debug('fallback/sendMessage/payload ' + JSON.stringify(payload));
 
   switch (cmd) {
     case action.version:
-      return sendValue(fallbacks.getVersion());
+      return fallbacks.getVersion();
     case action.native:
-      return sendValue(fallbacks.isNative());
+      return fallbacks.isNative();
     case action.mobile:
-      return sendValue(fallbacks.isMobile());
+      return fallbacks.isMobile();
     case action.ios:
-      return sendValue(fallbacks.isIos());
+      return fallbacks.isIos();
     case action.android:
-      return sendValue(fallbacks.isAndroid());
+      return fallbacks.isAndroid();
     case action.openLink:
-      return sendValue(fallbacks.openLink.apply(null, payload));
+      return fallbacks.openLink.apply(null, payload);
     case action.nativeUpload:
-      return sendValue(fallbacks.nativeUpload());
+      return fallbacks.nativeUpload();
     case action.langInfos:
-      return sendValue(fallbacks.langInfos());
+      return fallbacks.langInfos();
     case action.branchDefaultLang:
-      return sendValue(fallbacks.getBranchDefaultLanguage());
+      return fallbacks.getBranchDefaultLanguage();
     case action.prefContentLang:
-      return sendValue(fallbacks.getPreferredContentLocale.apply(null, payload));
+      return fallbacks.getPreferredContentLocale.apply(null, payload);
     default:
       // should actualy never ever happen
       throw new Error('Command ' + cmd + ' not supported by driver');
   }
-}
-
-/**
- * Fake values as real calls
- *
- * Binds all values to the connect promise
- * @param {any} val that will be sent when it's ready
- * @return {Promise<any>} the promissified val
- */
-async function sendValue(val) {
-  log.info('fallback/sendValue ' + JSON.stringify(val));
-  return connection.then(() => val);
 }

--- a/src/lib/connection/connector/postmessage-legacy.js
+++ b/src/lib/connection/connector/postmessage-legacy.js
@@ -5,6 +5,9 @@ import {
   resolve as resolvePromise,
   get as getPromise
 } from '../manager.js';
+
+import { sendMessage as fallBackSendMessage } from './fallback.js';
+
 let log = require('loglevel');
 
 let connection = null;
@@ -116,7 +119,7 @@ const sendMessage = store => async (cmd, ...payload) => {
     case actions.nativeUpload:
       return sendInvocationCall(invocationMapping[cmd], payload);
     default:
-      throw new Error('Command ' + cmd + ' not supported by driver');
+      return sendValue(fallBackSendMessage.apply(null, [cmd, ...payload]));
   }
 };
 

--- a/test/lib/connection/connector/postmessage-legacy.test.js
+++ b/test/lib/connection/connector/postmessage-legacy.test.js
@@ -70,38 +70,26 @@ describe('connector/postmessage-legacy', function() {
           stubPostMessage(info);
         });
 
-        it(command.ios, async () => {
+        it('should reject on unknown commands', async () => {
           let sendFn = await connect();
-          let ios = await sendFn(command.ios);
-          expect(ios).to.equal(true);
+          return expect(sendFn('unknown-asdf-command')).to.be.rejected;
         });
 
-        it(command.android, async () => {
-          let sendFn = await connect();
-          let android = await sendFn(command.android);
-          expect(android).to.equal(false);
-        });
+        describe('accepts all comands', async function() {
+          // mock window open
+          window.open = function() {};
 
-        it(command.mobile, async () => {
-          let sendFn = await connect();
-          let mobile = await sendFn(command.mobile);
-          expect(mobile).to.equal(true);
-        });
+          let commandData = {
+            prefContentLang: ['de_DE', 'en_US']
+          };
 
-        it(command.version, async () => {
-          let sendFn = await connect();
-          let version = await sendFn(command.version);
-          expect(version).to.equal(mockVersion);
-        });
-
-        it('throw error on unknown commands', async () => {
-          let sendFn = await connect();
-          let data = 'Command unknown not supported by driver';
-
-          try {
-            await sendFn('unknown');
-          } catch (error) {
-            expect(error.message).to.equal(data);
+          for (let cmd in command) {
+            if (command.hasOwnProperty(cmd)) {
+              it('command.' + cmd, async () => {
+                let sendFn = await connect();
+                return expect(sendFn(command[cmd], commandData[cmd])).to.be.fulfilled;
+              });
+            }
           }
         });
       });

--- a/test/lib/connection/connector/postmessage-legacy.test.js
+++ b/test/lib/connection/connector/postmessage-legacy.test.js
@@ -72,7 +72,7 @@ describe('connector/postmessage-legacy', function() {
 
         it('should reject on unknown commands', async () => {
           let sendFn = await connect();
-          return expect(sendFn('unknown-asdf-command')).to.be.rejected;
+          return expect(sendFn('unknown-command')).to.be.rejected;
         });
 
         describe('accepts all comands', async function() {


### PR DESCRIPTION
This adds a the handling of unknown commands with the fallback to the postmessage-legacy protocol. 

To test: 
- the KPI plugin should give the contentLanguage with v3.4, v3.5 and v3.6