### PR TITLE
Adds runtime transform, removes polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,16 +54,17 @@
   "size-limit": [
     {
       "path": "src/main.js",
-      "limit": "40 KB"
+      "limit": "9 KB"
     }
   ],
   "dependencies": {
+    "babel-runtime": "6.26.0",
     "loglevel": "^1.6.1"
   },
   "devDependencies": {
     "babel": "^6.23.0",
     "babel-plugin-external-helpers": "^6.22.0",
-    "babel-polyfill": "^6.26.0",
+    "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,14 +22,26 @@ const defaultBrowserPluginOptions = [
   commonjs(),
   babel({
     babelrc: false, // stops babel from using .babelrc files
-    plugins: ['external-helpers'], // [1]
+    plugins: [
+      [
+        'transform-runtime',
+        {
+          helpers: false,
+          polyfill: false,
+          runtimeHelpers: true,
+          regenerator: true,
+          moduleName: 'babel-runtime'
+        }
+      ],
+      'external-helpers'
+    ], // [1]
     presets: [
       [
         'env',
         {
           modules: false, // stop module conversion
           targets: {
-            browsers: ['last 2 versions'] // whatever you want here
+            browsers: ['last 2 versions', 'IE >= 10'] // whatever you want here
           }
         }
       ]

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 /**
  * interface exports
  */


### PR DESCRIPTION
This changes the babel polyfill to the runtime generator, which insert only the needed polyfills and reduces the file size of the bundles. Also the polyfills are only applied to the browser builds.