### PR TITLE
Add jsdoc2md script and api markdown file

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,157 @@
+## Members
+
+<dl>
+<dt><a href="#log">log</a></dt>
+<dd><p>interface exports</p>
+</dd>
+</dl>
+
+## Functions
+
+<dl>
+<dt><a href="#deviceCanDownload">deviceCanDownload()</a> ⇒ <code>Promise.&lt;boolean&gt;</code></dt>
+<dd><p>Check if device is able to perform a download.</p>
+</dd>
+<dt><a href="#isIosDevice">isIosDevice()</a> ⇒ <code>Promise.&lt;boolean&gt;</code></dt>
+<dd><p>Check if device is using ios.</p>
+</dd>
+<dt><a href="#isAndroidDevice">isAndroidDevice()</a> ⇒ <code>Promise.&lt;boolean&gt;</code></dt>
+<dd><p>Check if device is using android.</p>
+</dd>
+<dt><a href="#getAppVersion">getAppVersion()</a> ⇒ <code>Promise.&lt;string&gt;</code></dt>
+<dd><p>Get the version of the Staffbase App.</p>
+</dd>
+<dt><a href="#isNativeApp">isNativeApp()</a> ⇒ <code>Promise.&lt;boolean&gt;</code></dt>
+<dd><p>Check if app is native.</p>
+</dd>
+<dt><a href="#isMobileApp">isMobileApp()</a> ⇒ <code>Promise.&lt;boolean&gt;</code></dt>
+<dd><p>Check if app is mobile.</p>
+</dd>
+<dt><a href="#openLink">openLink(url)</a> ⇒ <code>Promise.&lt;any&gt;</code></dt>
+<dd><p>Open a link through the app.</p>
+<p>Where Staffbase decides which browser (External/Internal)
+should be used.</p>
+</dd>
+<dt><a href="#openLinkExternal">openLinkExternal(url)</a> ⇒ <code>Promise.&lt;any&gt;</code></dt>
+<dd><p>Open a link explicitly in the external browser.</p>
+</dd>
+<dt><a href="#openLinkInternal">openLinkInternal(url)</a> ⇒ <code>Promise.&lt;any&gt;</code></dt>
+<dd><p>Open a link explicitly in the internal browser.</p>
+</dd>
+<dt><a href="#getBranchLanguages">getBranchLanguages()</a> ⇒ <code>Promise.&lt;any&gt;</code></dt>
+<dd><p>Get content languages configured in the app.</p>
+</dd>
+<dt><a href="#getBranchDefaultLanguage">getBranchDefaultLanguage()</a> ⇒ <code>Promise.&lt;any&gt;</code></dt>
+<dd><p>Get content languages configured in the app.</p>
+</dd>
+<dt><a href="#getPreferredContentLocale">getPreferredContentLocale(content)</a> ⇒ <code>Promise.&lt;string&gt;</code></dt>
+<dd><p>Gets the choosen language from a given content object</p>
+</dd>
+</dl>
+
+<a name="log"></a>
+
+## log
+interface exports
+
+**Kind**: global variable  
+<a name="deviceCanDownload"></a>
+
+## deviceCanDownload() ⇒ <code>Promise.&lt;boolean&gt;</code>
+Check if device is able to perform a download.
+
+**Kind**: global function  
+<a name="isIosDevice"></a>
+
+## isIosDevice() ⇒ <code>Promise.&lt;boolean&gt;</code>
+Check if device is using ios.
+
+**Kind**: global function  
+<a name="isAndroidDevice"></a>
+
+## isAndroidDevice() ⇒ <code>Promise.&lt;boolean&gt;</code>
+Check if device is using android.
+
+**Kind**: global function  
+<a name="getAppVersion"></a>
+
+## getAppVersion() ⇒ <code>Promise.&lt;string&gt;</code>
+Get the version of the Staffbase App.
+
+**Kind**: global function  
+<a name="isNativeApp"></a>
+
+## isNativeApp() ⇒ <code>Promise.&lt;boolean&gt;</code>
+Check if app is native.
+
+**Kind**: global function  
+<a name="isMobileApp"></a>
+
+## isMobileApp() ⇒ <code>Promise.&lt;boolean&gt;</code>
+Check if app is mobile.
+
+**Kind**: global function  
+<a name="openLink"></a>
+
+## openLink(url) ⇒ <code>Promise.&lt;any&gt;</code>
+Open a link through the app.
+
+Where Staffbase decides which browser (External/Internal)
+should be used.
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>string</code> | the url to open in the browser |
+
+<a name="openLinkExternal"></a>
+
+## openLinkExternal(url) ⇒ <code>Promise.&lt;any&gt;</code>
+Open a link explicitly in the external browser.
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>string</code> | the url to open in the browser |
+
+<a name="openLinkInternal"></a>
+
+## openLinkInternal(url) ⇒ <code>Promise.&lt;any&gt;</code>
+Open a link explicitly in the internal browser.
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>string</code> | the url to open in the browser |
+
+<a name="getBranchLanguages"></a>
+
+## getBranchLanguages() ⇒ <code>Promise.&lt;any&gt;</code>
+Get content languages configured in the app.
+
+**Kind**: global function  
+<a name="getBranchDefaultLanguage"></a>
+
+## getBranchDefaultLanguage() ⇒ <code>Promise.&lt;any&gt;</code>
+Get content languages configured in the app.
+
+**Kind**: global function  
+<a name="getPreferredContentLocale"></a>
+
+## getPreferredContentLocale(content) ⇒ <code>Promise.&lt;string&gt;</code>
+Gets the choosen language from a given content object
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| content | <code>object</code> \| <code>array</code> | the content to choose the locale from |
+
+**Example**  
+```js
+getPreferredContentLocale(['de_DE', 'en_EN']) // => 'de_DE'
+   getPreferredContentLocale({'de_DE': {1,'eins'}, 'en_EN': {1: 'one'}}) // => 'de_DE'
+```

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "npm run lint-code && npm run lint-size",
     "lint-code": "npx eslint src test",
     "lint-size": "npx size-limit",
-    "fix": "eslint --fix 'src/**/*.js' 'test/**/*.js'"
+    "fix": "eslint --fix 'src/**/*.js' 'test/**/*.js'",
+    "doc": "mkdir -p doc && npx jsdoc2md src/main.js > doc/api.md"
   },
   "repository": {
     "type": "git",
@@ -57,6 +58,7 @@
   ],
   "dependencies": {
     "babel-runtime": "6.26.0",
+    "jsdoc": "^3.5.5",
     "loglevel": "^1.6.1"
   },
   "devDependencies": {
@@ -76,6 +78,7 @@
     "eslint-plugin-prettier": "^2.6.2",
     "jest": "23.5.0",
     "jest-extended": "0.8.1",
+    "jsdoc-to-markdown": "^4.0.1",
     "prettier": "^1.14.2",
     "prettier-eslint": "^8.8.2",
     "rollup": "^0.64.1",

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -3,7 +3,7 @@ import sendMessage from './connection/connection';
 let log = require('loglevel');
 
 /**
- * Get the version of the Staffbase App
+ * Get the version of the Staffbase App.
  *
  * @return {Promise<string>}
  */
@@ -13,7 +13,7 @@ export const getVersion = async () => {
 };
 
 /**
- * Check if app is native
+ * Check if app is native.
  *
  * @return {Promise<boolean>}
  */
@@ -23,7 +23,7 @@ export const isNative = async () => {
 };
 
 /**
- * Check if app is mobile
+ * Check if app is mobile.
  *
  * @return {Promise<boolean>}
  */
@@ -33,7 +33,7 @@ export const isMobile = async () => {
 };
 
 /**
- * Open a link through the app
+ * Open a link through the app.
  *
  * Where Staffbase decides which browser (External/Internal)
  * should be used.
@@ -48,7 +48,7 @@ export const openLink = async url => {
 };
 
 /**
- * Open a link explicitly in the external browser
+ * Open a link explicitly in the external browser.
  *
  * @param {string} url the url to open in the browser
  *
@@ -60,7 +60,7 @@ export const openLinkExternal = async url => {
 };
 
 /**
- * Open a link explicitly in the internal browser
+ * Open a link explicitly in the internal browser.
  *
  * @param {string} url the url to open in the browser
  *

--- a/src/lib/device.js
+++ b/src/lib/device.js
@@ -6,7 +6,7 @@ import compareVersions from 'compare-versions';
 import catchLinks from './polyfills/catch-links';
 let log = require('loglevel');
 /**
- * Check if device is using ios
+ * Check if device is using ios.
  *
  * @return {Promise<boolean>}
  */
@@ -16,7 +16,7 @@ export const isIos = async () => {
 };
 
 /**
- * Check if device is using android
+ * Check if device is using android.
  *
  * @return {Promise<boolean>}
  */

--- a/src/main.js
+++ b/src/main.js
@@ -5,20 +5,133 @@
 let log = require('loglevel');
 log.enableAll(); /* experimental */
 
-export { canDownload as deviceCanDownload } from './lib/device';
-export { isIos as isIosDevice } from './lib/device';
-export { isAndroid as isAndroidDevice } from './lib/device';
+import * as device from './lib/device';
+import * as app from './lib/app';
 
-export { getVersion as getAppVersion } from './lib/app';
-export { isNative as isNativeApp } from './lib/app';
-export { isMobile as isMobileApp } from './lib/app';
+/**
+ * Check if device is able to perform a download.
+ *
+ * @return {Promise<boolean>}
+ */
+export async function deviceCanDownload() {
+  return device.canDownload();
+}
 
-export { openLink } from './lib/app';
-export { openLinkExternal } from './lib/app';
-export { openLinkInternal } from './lib/app';
-export { getBranchLanguages } from './lib/app';
-export { getBranchDefaultLanguage } from './lib/app';
-export { getPreferredContentLocale } from './lib/app';
+/**
+ * Check if device is using ios.
+ *
+ * @return {Promise<boolean>}
+ */
+export async function isIosDevice() {
+  return device.isIos();
+}
 
+/**
+ * Check if device is using android.
+ *
+ * @return {Promise<boolean>}
+ */
+export async function isAndroidDevice() {
+  return device.isAndroid();
+}
+
+/**
+ * Get the version of the Staffbase App.
+ *
+ * @return {Promise<string>}
+ */
+export async function getAppVersion() {
+  return app.getVersion();
+}
+
+/**
+ * Check if app is native.
+ *
+ * @return {Promise<boolean>}
+ */
+export async function isNativeApp() {
+  return app.isNative();
+}
+
+/**
+ * Check if app is mobile.
+ *
+ * @return {Promise<boolean>}
+ */
+export async function isMobileApp() {
+  return app.isMobile();
+}
+
+/**
+ * Open a link through the app.
+ *
+ * Where Staffbase decides which browser (External/Internal)
+ * should be used.
+ *
+ * @param {string} url the url to open in the browser
+ *
+ * @return {Promise<any>}
+ */
+export async function openLink() {
+  return app.openLink();
+}
+
+/**
+ * Open a link explicitly in the external browser.
+ *
+ * @param {string} url the url to open in the browser
+ *
+ * @return {Promise<any>}
+ */
+export async function openLinkExternal() {
+  return app.openLinkExternal();
+}
+
+/**
+ * Open a link explicitly in the internal browser.
+ *
+ * @param {string} url the url to open in the browser
+ *
+ * @return {Promise<any>}
+ */
+export async function openLinkInternal() {
+  return app.openLinkInternal();
+}
+
+/**
+ * Get content languages configured in the app.
+ *
+ * @return {Promise<any>}
+ */
+export async function getBranchLanguages() {
+  return app.getBranchLanguages();
+}
+
+/**
+ * Get content languages configured in the app.
+ *
+ * @return {Promise<any>}
+ */
+export async function getBranchDefaultLanguage() {
+  return app.getBranchDefaultLanguage();
+}
+
+/**
+ * Gets the choosen language from a given content object
+ *
+ * @example
+ *    getPreferredContentLocale(['de_DE', 'en_EN']) // => 'de_DE'
+ *    getPreferredContentLocale({'de_DE': {1,'eins'}, 'en_EN': {1: 'one'}}) // => 'de_DE'
+ *
+ * @param {object|array} content the content to choose the locale from
+ *
+ * @return {Promise<string>}
+ */
+export async function getPreferredContentLocale() {
+  return app.getPreferredContentLocale();
+}
+
+/** @inheritdoc */
 export { getLanguageInfos } from './lib/app'; /* experimental */
+/** @inheritdoc */
 export { openNativeFileDialog } from './lib/app'; /* experimental */


### PR DESCRIPTION
This PR includes the addition of jsdoc2md and a coresponding npm script which will generate api.md the interface documentation file from main.js source. To enable jsdoc  on main.js it was necessary to refactor main.js with thin wrappers around the reexports else jsdoc would just skip eveything.