### PR TITLE
chore: pervorm npm publish on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
       "@semantic-release/git"
     ],
     "publish": [
-      "@semantic-release/github"
+      "@semantic-release/github",
+      "@semantic-release/npm"
     ]
   },
   "directories": {


### PR DESCRIPTION
Something went wrong on the last release because the npm publish was missing.