### PR TITLE
fix(docs): switch from relative to absolute links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ npm install @staffbase/plugins-client-sdk
 
 ## API Reference
 
-Please look into our [API documentation](doc/api.md)
+Please look into our [API documentation](https://github.com/Staffbase/plugins-client-sdk/blob/master/doc/api.md)
 
 ## Usage
 
-Please look into our [Usage documentation](doc/usage.md)
+Please look into our [Usage documentation](https://github.com/Staffbase/plugins-client-sdk/blob/master/doc/usage.md)
 
 
 ## Contribution


### PR DESCRIPTION
## Description
Switch from relative to absolute links in README.md to fix path mistake in npm.

## Related Issue
[https://mitarbeiterapp.atlassian.net/browse/PL-585](https://mitarbeiterapp.atlassian.net/browse/PL-585)

## Motivation and Context
Needs to be changed to get right links in README.md on npm and yarn websites. 
