### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9815,9 +9815,9 @@ spdx-expression-validate@2.0.0:
     spdx-expression-parse "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz#eb1e97ad99b11bf3f82a3b71a0472dd9a00f2ecf"
-  integrity sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz#0d9becccde7003d6c658d487dd48a32f0bf3014b"
+  integrity sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==
 
 spdx-ranges@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [7.24.2](https://github.com/npm/cli/releases/tag/v7.24.2).

<details open>
<summary><strong>Updated (2)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [json-schema](https://www.npmjs.com/package/json-schema/v/0.4.0) | `0.2.3` → `0.4.0` | [github](https://github.com/kriszyp/json-schema) | **[Moderate]** json-schema is vulnerable to Prototype Pollution ([ref](https://github.com/advisories/GHSA-896r-f27r-55mw)) |
| [jsprim](https://www.npmjs.com/package/jsprim/v/1.4.2) | `1.4.1` → `1.4.2` | [github](https://github.com/joyent/node-jsprim) | - |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)