### PR TITLE
feat: add getusercontentlanguage to client sdk

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,8 @@ Licensed under the Apache License, Version 2.0: <http://www.apache.org/licenses/
     </td>
     <td>
       <b>Staffbase GmbH</b>
-      <br />Staffbase is an internal communications platform built to revolutionize the way you work and unite your company. Staffbase is hiring: <a href="https://jobs.staffbase.com" target="_blank" rel="noreferrer">jobs.staffbase.com</a>
-      <br /><a href="https://github.com/Staffbase" target="_blank" rel="noreferrer">GitHub</a> | <a href="https://staffbase.com/" target="_blank" rel="noreferrer">Website</a> | <a href="https://jobs.staffbase.com" target="_blank" rel="noreferrer">Jobs</a>
+      <br />Staffbase is an internal communications platform built to revolutionize the way you work and unite your company. Staffbase is hiring: <a href="https://staffbase.com/jobs/" target="_blank" rel="noreferrer">jobs.staffbase.com</a>
+      <br /><a href="https://github.com/Staffbase" target="_blank" rel="noreferrer">GitHub</a> | <a href="https://staffbase.com/" target="_blank" rel="noreferrer">Website</a> | <a href="https://staffbase.com/jobs/" target="_blank" rel="noreferrer">Jobs</a>
     </td>
   </tr>
 </table>

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ To run the tests a simple `# yarn jest` command in the root directory will suffi
 
 ## License
 
-Copyright 20224 Staffbase GmbH.
+Copyright 2024 Staffbase GmbH.
 
 Licensed under the Apache License, Version 2.0: <http://www.apache.org/licenses/LICENSE-2.0>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ To run the tests a simple `# yarn jest` command in the root directory will suffi
 
 ## License
 
-Copyright 2018 Staffbase GmbH.
+Copyright 20224 Staffbase GmbH.
 
 Licensed under the Apache License, Version 2.0: <http://www.apache.org/licenses/LICENSE-2.0>
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,6 +50,9 @@ should be used.</p>
 <dt><a href="#getPreferredContentLocale">getPreferredContentLocale(content)</a> ⇒ <code>Promise.&lt;string&gt;</code></dt>
 <dd><p>Gets the chosen language from a given content object</p>
 </dd>
+<dt><a href="#getUserContentLanguage">getUserContentLanguage()</a> ⇒ <code>Promise.&lt;any&gt;</code></dt>
+<dd><p>Get the current user&#39;s content language, fallback to branch default language</p>
+</dd>
 </dl>
 
 <a name="openNativeShareDialog"></a>
@@ -178,3 +181,9 @@ Gets the chosen language from a given content object
 getPreferredContentLocale(['de_DE', 'en_EN']) // => 'de_DE'
    getPreferredContentLocale({'de_DE': {1,'eins'}, 'en_EN': {1: 'one'}}) // => 'de_DE'
 ```
+<a name="getUserContentLanguage"></a>
+
+## getUserContentLanguage() ⇒ <code>Promise.&lt;any&gt;</code>
+Get the current user's content language, fallback to branch default language
+
+**Kind**: global function  

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,8 +50,8 @@ should be used.</p>
 <dt><a href="#getPreferredContentLocale">getPreferredContentLocale(content)</a> ⇒ <code>Promise.&lt;string&gt;</code></dt>
 <dd><p>Gets the chosen language from a given content object</p>
 </dd>
-<dt><a href="#getUserContentLanguage">getUserContentLanguage()</a> ⇒ <code>Promise.&lt;any&gt;</code></dt>
-<dd><p>Get the current user&#39;s content language, fallback to branch default language</p>
+<dt><a href="#getUserContentLocale">getUserContentLocale()</a> ⇒ <code>Promise.&lt;any&gt;</code></dt>
+<dd><p>Get the current user&#39;s content locale, fallback to branch default locale</p>
 </dd>
 </dl>
 
@@ -181,9 +181,9 @@ Gets the chosen language from a given content object
 getPreferredContentLocale(['de_DE', 'en_EN']) // => 'de_DE'
    getPreferredContentLocale({'de_DE': {1,'eins'}, 'en_EN': {1: 'one'}}) // => 'de_DE'
 ```
-<a name="getUserContentLanguage"></a>
+<a name="getUserContentLocale"></a>
 
-## getUserContentLanguage() ⇒ <code>Promise.&lt;any&gt;</code>
-Get the current user's content language, fallback to branch default language
+## getUserContentLocale() ⇒ <code>Promise.&lt;any&gt;</code>
+Get the current user's content locale, fallback to branch default locale
 
 **Kind**: global function  

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -164,13 +164,13 @@ As a developer you can request various informations from the Staffbase app.
    }
    ```
 
-1. `getUserConentLanguage` -> string
+1. `getUserConentLocale` -> string
 
-   the content language which is set for current user. Fallback is the branch default language
+   the content locale which is set for current user. Fallback is the branch default locale
 
    ```js
-   // example for user with german content language in an english app
-   getUserConentLanguage().then(function (locale) {
+   // example for user with german content locale in an english app
+   getUserConentLocale().then(function (locale) {
         console.log(locale); // 'de_DE'
     })
    ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -164,18 +164,15 @@ As a developer you can request various informations from the Staffbase app.
    }
    ```
 
-1. `getUserConentLanguage` -> object
+1. `getUserConentLanguage` -> string
 
    the content language which is set for current user. Fallback is the branch default language
 
    ```js
-   // example for german in an english app
-   {
-           key: 'de',
-           locale: 'de_DE',
-           name: 'Deutsch',
-           localized: 'German' // this depends on the app language
-    }
+   // example for user with german content language in an english app
+   getUserConentLanguage().then(function (locale) {
+        console.log(locale); // 'de_DE'
+    })
    ```
 
 ### Invoking native methods

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -164,13 +164,13 @@ As a developer you can request various informations from the Staffbase app.
    }
    ```
 
-1. `getUserConentLocale` -> string
+1. `getUserContentLocale` -> string
 
    the content locale which is set for current user. Fallback is the branch default locale
 
    ```js
    // example for user with german content locale in an english app
-   getUserConentLocale().then(function (locale) {
+   getUserContentLocale().then(function (locale) {
         console.log(locale); // 'de_DE'
     })
    ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -164,6 +164,20 @@ As a developer you can request various informations from the Staffbase app.
    }
    ```
 
+1. `getUserConentLanguage` -> object
+
+   the content language which is set for current user. Fallback is the branch default language
+
+   ```js
+   // example for german in an english app
+   {
+           key: 'de',
+           locale: 'de_DE',
+           name: 'Deutsch',
+           localized: 'German' // this depends on the app language
+    }
+   ```
+
 ### Invoking native methods
 
 With the SDK you can invoke methods, which are in the scope of the native app.

--- a/resources/index.html
+++ b/resources/index.html
@@ -614,9 +614,9 @@
                 <pre id="isBranchDefaultLang"></pre>
                 <br />
                 <strong
-                  >getUserContentLanguage() - User Content Language:</strong
+                  >getUserConentLocale() - User Content Locale:</strong
                 >
-                <pre id="isUserContentLang"></pre>
+                <pre id="isUserContentLocale"></pre>
                 <br />
                 <strong>getContentLanguages() - Content Languages:</strong>
                 <pre id="isContentLangs"></pre>
@@ -804,16 +804,16 @@
                       error
                   );
               });
-     PluginSDK.getUserContentLanguage()
-              .then(function (isUserContentLang) {
-                  console.log("User Content Language: ", isUserContentLang);
+     PluginSDK.getUserContentLocale()
+              .then(function (isUserContentLocale) {
+                  console.log("User Content Language: ", isUserContentLocale);
                   document.getElementById(
-                      "isUserContentLang"
-                  ).textContent = JSON.stringify(isUserContentLang, undefined, 2);
+                      "isUserContentLocale"
+                  ).textContent = JSON.stringify(isUserContentLocale, undefined, 2);
               })
               .catch(function (error) {
                   console.warn(
-                      "Something went wrong with getUserContentLanguage(): ",
+                      "Something went wrong with getUserContentLocale(): ",
                       error
                   );
               });

--- a/resources/index.html
+++ b/resources/index.html
@@ -614,7 +614,7 @@
                 <pre id="isBranchDefaultLang"></pre>
                 <br />
                 <strong
-                  >getUserConentLocale() - User Content Locale:</strong
+                  >getUserContentLocale() - User Content Locale:</strong
                 >
                 <pre id="isUserContentLocale"></pre>
                 <br />

--- a/resources/index.html
+++ b/resources/index.html
@@ -613,6 +613,11 @@
                 >
                 <pre id="isBranchDefaultLang"></pre>
                 <br />
+                <strong
+                  >getUserContentLanguage() - User Content Language:</strong
+                >
+                <pre id="isUserContentLang"></pre>
+                <br />
                 <strong>getContentLanguages() - Content Languages:</strong>
                 <pre id="isContentLangs"></pre>
                 <br />

--- a/resources/index.html
+++ b/resources/index.html
@@ -799,6 +799,19 @@
                       error
                   );
               });
+     PluginSDK.getUserContentLanguage()
+              .then(function (isUserContentLang) {
+                  console.log("User Content Language: ", isUserContentLang);
+                  document.getElementById(
+                      "isUserContentLang"
+                  ).textContent = JSON.stringify(isUserContentLang, undefined, 2);
+              })
+              .catch(function (error) {
+                  console.warn(
+                      "Something went wrong with getUserContentLanguage(): ",
+                      error
+                  );
+              });
      PluginSDK.getContentLanguages()
               .then(function (isContentLangs) {
                   console.log("Content Languages: ", isContentLangs);

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -154,7 +154,7 @@ export const getPreferredContentLocale = async (content) => {
  *
  * @return {Promise<Object>}
  */
-export const getUserContentLanguage = async () => {
-  log.debug('app/getUserContentLanguage');
-  return sendMessage(cmd.langInfos).then((res) => res.userContentLanguage.locale);
+export const getUserContentLocale = async () => {
+  log.debug('app/getUserContentLocale');
+  return sendMessage(cmd.langInfos).then((res) => res.userContentLocale);
 };

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -148,3 +148,13 @@ export const getPreferredContentLocale = async (content) => {
   log.debug('app/getPreferredContentLocale');
   return sendMessage(cmd.prefContentLang, content);
 };
+
+/**
+ * Get the default content language configured for the branch.
+ *
+ * @return {Promise<Object>}
+ */
+export const getUserContentLanguage = async () => {
+  log.debug('app/getUserContentLanguage');
+  return sendMessage(cmd.langInfos).then((res) => res.userContentLanguage);
+};

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -156,5 +156,5 @@ export const getPreferredContentLocale = async (content) => {
  */
 export const getUserContentLanguage = async () => {
   log.debug('app/getUserContentLanguage');
-  return sendMessage(cmd.langInfos).then((res) => res.userContentLanguage);
+  return sendMessage(cmd.langInfos).then((res) => res.userContentLanguage.locale);
 };

--- a/src/lib/connection/commands.js
+++ b/src/lib/connection/commands.js
@@ -22,7 +22,8 @@ export const commands = {
   nativeShare: 'nativeShareDialog',
   langInfos: 'getLanguageInfos',
   branchDefaultLang: 'getBranchDefaultLanguage',
-  prefContentLang: 'getPreferredContentLocale'
+  prefContentLang: 'getPreferredContentLocale',
+  userContentLang: 'getUserContentLanguage',
 };
 
 /**

--- a/src/lib/connection/commands.js
+++ b/src/lib/connection/commands.js
@@ -23,7 +23,7 @@ export const commands = {
   langInfos: 'getLanguageInfos',
   branchDefaultLang: 'getBranchDefaultLanguage',
   prefContentLang: 'getPreferredContentLocale',
-  userContentLang: 'getUserContentLanguage',
+  userContentLang: 'getUserContentLanguage'
 };
 
 /**

--- a/src/lib/connection/commands.js
+++ b/src/lib/connection/commands.js
@@ -23,7 +23,7 @@ export const commands = {
   langInfos: 'getLanguageInfos',
   branchDefaultLang: 'getBranchDefaultLanguage',
   prefContentLang: 'getPreferredContentLocale',
-  userContentLang: 'getUserContentLanguage'
+  userContentLocale: 'getUserContentLocale'
 };
 
 /**

--- a/src/lib/connection/connector/fallback-handlers.js
+++ b/src/lib/connection/connector/fallback-handlers.js
@@ -171,7 +171,8 @@ export const getPreferredContentLocale = (content) => {
  */
 export const getUserContentLanguage = () => {
   log.debug('fallback/getUserContentLanguage');
+  const locale = getBranchDefaultLanguage().locale;
+  // TO-DO: implement user language detection
 
-  // TODO
-  return locales[currentLanguage] || locales.en;
+  return locale;
 };

--- a/src/lib/connection/connector/fallback-handlers.js
+++ b/src/lib/connection/connector/fallback-handlers.js
@@ -173,7 +173,5 @@ export const getUserContentLocale = () => {
   log.debug('fallback/getUserContentLocale');
   const locale = getBranchDefaultLanguage().locale;
 
-  // TO-DO: implement user language detection
-
   return locale;
 };

--- a/src/lib/connection/connector/fallback-handlers.js
+++ b/src/lib/connection/connector/fallback-handlers.js
@@ -163,3 +163,15 @@ export const getPreferredContentLocale = (content) => {
     return keys[index] || keys[0];
   }
 };
+
+/**
+ * Get the current user's content language, fallback to branch default language
+ *
+ * @return {Object} the language object
+ */
+export const getUserContentLanguage = () => {
+  log.debug('fallback/getUserContentLanguage');
+
+  // TODO
+  return locales[currentLanguage] || locales.en;
+};

--- a/src/lib/connection/connector/fallback-handlers.js
+++ b/src/lib/connection/connector/fallback-handlers.js
@@ -165,13 +165,14 @@ export const getPreferredContentLocale = (content) => {
 };
 
 /**
- * Get the current user's content language, fallback to branch default language
+ * Get the current user's content locale, fallback to branch default locale
  *
- * @return {Object} the language object
+ * @return {String} the user's content locale
  */
-export const getUserContentLanguage = () => {
-  log.debug('fallback/getUserContentLanguage');
+export const getUserContentLocale = () => {
+  log.debug('fallback/getUserContentLocale');
   const locale = getBranchDefaultLanguage().locale;
+
   // TO-DO: implement user language detection
 
   return locale;

--- a/src/lib/connection/connector/fallback.js
+++ b/src/lib/connection/connector/fallback.js
@@ -68,6 +68,8 @@ export const sendMessage = async (cmd, ...payload) => {
       return fallbacks.getBranchDefaultLanguage();
     case action.prefContentLang:
       return fallbacks.getPreferredContentLocale.apply(null, payload);
+    case action.userContentLang:
+      return fallbacks.getUserContentLanguage();
     case action.nativeUpload:
     case action.nativeShare:
       return fallbacks.unSupported(cmd);

--- a/src/lib/connection/connector/fallback.js
+++ b/src/lib/connection/connector/fallback.js
@@ -68,8 +68,8 @@ export const sendMessage = async (cmd, ...payload) => {
       return fallbacks.getBranchDefaultLanguage();
     case action.prefContentLang:
       return fallbacks.getPreferredContentLocale.apply(null, payload);
-    case action.userContentLang:
-      return fallbacks.getUserContentLanguage();
+    case action.userContentLocale:
+      return fallbacks.getUserContentLocale();
     case action.nativeUpload:
     case action.nativeShare:
       return fallbacks.unSupported(cmd);

--- a/src/main.js
+++ b/src/main.js
@@ -118,11 +118,11 @@ export const getContentLanguages = async () => app.getContentLanguages();
 export const getPreferredContentLocale = async (content) => app.getPreferredContentLocale(content);
 
 /**
- * Get the current user's content language, fallback to branch default language
+ * Get the current user's content locale, fallback to branch default locale
  * @function
  * @return {Promise<any>}
  */
-export const getUserContentLanguage = async () => app.getUserContentLanguage();
+export const getUserContentLocale = async () => app.getUserContentLocale();
 
 /**
  * Open a share dialog on native devices

--- a/src/main.js
+++ b/src/main.js
@@ -118,6 +118,13 @@ export const getContentLanguages = async () => app.getContentLanguages();
 export const getPreferredContentLocale = async (content) => app.getPreferredContentLocale(content);
 
 /**
+ * Get the current user's content language, fallback to branch default language
+ * @function
+ * @return {Promise<any>}
+ */
+export const getUserContentLanguage = async () => app.getUserContentLanguage();
+
+/**
  * Open a share dialog on native devices
  *
  * @example

--- a/test/lib/app.test.js
+++ b/test/lib/app.test.js
@@ -24,7 +24,7 @@ const langInfos = {
   branchDefaultLanguage: branchLanguages.de,
   deviceLanguage: branchLanguages.en,
   contentLanguages: branchLanguages,
-  userContentLanguage: branchLanguages.en
+  userContentLocale: branchLanguages.en.locale
 };
 
 const mockVersion = '3.6-dev';
@@ -81,9 +81,9 @@ describe('app', () => {
     expect(await App.getPreferredContentLocale(['de_DE', 'EN_US'])).toEqual('de_DE');
   });
 
-  it('should get the current user content language', async () => {
+  it('should get the current user content locale', async () => {
     messageStub.changeMsg(langInfoMsg);
-    expect(await App.getUserContentLanguage()).toEqual(langInfos.userContentLanguage.locale);
+    expect(await App.getUserContentLocale()).toEqual(langInfos.userContentLocale);
   });
 
   it('should open links', async () => {

--- a/test/lib/app.test.js
+++ b/test/lib/app.test.js
@@ -83,7 +83,7 @@ describe('app', () => {
 
   it('should get the current user content language', async () => {
     messageStub.changeMsg(langInfoMsg);
-    expect(await App.getUserContentLanguage()).toEqual(langInfos.userContentLanguage);
+    expect(await App.getUserContentLanguage()).toEqual(langInfos.userContentLanguage.locale);
   });
 
   it('should open links', async () => {

--- a/test/lib/app.test.js
+++ b/test/lib/app.test.js
@@ -23,7 +23,8 @@ const langInfos = {
   branchLanguages: branchLanguages,
   branchDefaultLanguage: branchLanguages.de,
   deviceLanguage: branchLanguages.en,
-  contentLanguages: branchLanguages
+  contentLanguages: branchLanguages,
+  userContentLanguage: branchLanguages.en
 };
 
 const mockVersion = '3.6-dev';
@@ -78,6 +79,11 @@ describe('app', () => {
   it('should get the preferred content language', async () => {
     messageStub.changeMsg(['SUCCESS', 0, 'de_DE']);
     expect(await App.getPreferredContentLocale(['de_DE', 'EN_US'])).toEqual('de_DE');
+  });
+
+  it('should get the current user content language', async () => {
+    messageStub.changeMsg(langInfoMsg);
+    expect(await App.getUserContentLanguage()).toEqual(langInfos.userContentLanguage);
   });
 
   it('should open links', async () => {

--- a/test/lib/connection/connector/__snapshots__/fallback.test.js.snap
+++ b/test/lib/connection/connector/__snapshots__/fallback.test.js.snap
@@ -902,4 +902,13 @@ exports[`connector/fallback connect send function accepts all comands command.op
 
 exports[`connector/fallback connect send function accepts all comands command.prefContentLang 1`] = `"en_US"`;
 
+exports[`connector/fallback connect send function accepts all comands command.userContentLang 1`] = `
+{
+  "key": "en",
+  "locale": "en_US",
+  "localizedName": "English",
+  "name": "English",
+}
+`;
+
 exports[`connector/fallback connect send function accepts all comands command.version 1`] = `"3.4"`;

--- a/test/lib/connection/connector/__snapshots__/fallback.test.js.snap
+++ b/test/lib/connection/connector/__snapshots__/fallback.test.js.snap
@@ -902,13 +902,6 @@ exports[`connector/fallback connect send function accepts all comands command.op
 
 exports[`connector/fallback connect send function accepts all comands command.prefContentLang 1`] = `"en_US"`;
 
-exports[`connector/fallback connect send function accepts all comands command.userContentLang 1`] = `
-{
-  "key": "en",
-  "locale": "en_US",
-  "localizedName": "English",
-  "name": "English",
-}
-`;
+exports[`connector/fallback connect send function accepts all comands command.userContentLang 1`] = `"en_US"`;
 
 exports[`connector/fallback connect send function accepts all comands command.version 1`] = `"3.4"`;

--- a/test/lib/connection/connector/__snapshots__/fallback.test.js.snap
+++ b/test/lib/connection/connector/__snapshots__/fallback.test.js.snap
@@ -902,6 +902,6 @@ exports[`connector/fallback connect send function accepts all comands command.op
 
 exports[`connector/fallback connect send function accepts all comands command.prefContentLang 1`] = `"en_US"`;
 
-exports[`connector/fallback connect send function accepts all comands command.userContentLang 1`] = `"en_US"`;
+exports[`connector/fallback connect send function accepts all comands command.userContentLocale 1`] = `"en_US"`;
 
 exports[`connector/fallback connect send function accepts all comands command.version 1`] = `"3.4"`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add new method `getUserContentLanguage` to return the current user's content language.
Fallback is the branch defautl language (`getBranchDefaultLanguage()`).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** part in the readme.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Test plan:
<!--- Explain what has to be tested manually, to confirm the PR is ok -->