### PR TITLE
Use GH org vars instead of secrets

### DIFF
--- a/.github/workflows/techdocs.yml
+++ b/.github/workflows/techdocs.yml
@@ -15,5 +15,5 @@ jobs:
     with:
       entity-name: plugins-client-sdk
     secrets:
-      azure-account-name: ${{ secrets.TECHDOCS_AZURE_ACCOUNT_NAME }}
+      azure-account-name: ${{ vars.TECHDOCS_AZURE_ACCOUNT_NAME }}
       azure-account-key: ${{ secrets.TECHDOCS_AZURE_ACCESS_KEY }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request includes a small update to the `.github/workflows/techdocs.yml` file. The change replaces the use of `secrets.TECHDOCS_AZURE_ACCOUNT_NAME` with `vars.TECHDOCS_AZURE_ACCOUNT_NAME` for the `azure-account-name` configuration in the TechDocs workflow.

## Related Issue

CIV-740