### PR TITLE
Add English (United Kingdom) locale

### DIFF
--- a/src/model/locales.js
+++ b/src/model/locales.js
@@ -86,6 +86,12 @@ export default {
     name: 'English',
     localizedName: 'English'
   },
+  enGB: {
+    key: 'enGB',
+    locale: 'en_GB',
+    name: 'English (United Kingdom)',
+    localizedName: 'English (United Kingdom)'
+  },
   es: {
     key: 'es',
     locale: 'es_ES',

--- a/test/lib/connection/connector/__snapshots__/fallback.test.js.snap
+++ b/test/lib/connection/connector/__snapshots__/fallback.test.js.snap
@@ -109,6 +109,12 @@ exports[`connector/fallback connect send function accepts all comands command.la
       "localizedName": "English",
       "name": "English",
     },
+    "enGB": {
+      "key": "enGB",
+      "locale": "en_GB",
+      "localizedName": "English (United Kingdom)",
+      "name": "English (United Kingdom)",
+    },
     "es": {
       "key": "es",
       "locale": "es_ES",
@@ -541,6 +547,12 @@ exports[`connector/fallback connect send function accepts all comands command.la
       "locale": "en_US",
       "localizedName": "English",
       "name": "English",
+    },
+    "enGB": {
+      "key": "enGB",
+      "locale": "en_GB",
+      "localizedName": "English (United Kingdom)",
+      "name": "English (United Kingdom)",
     },
     "es": {
       "key": "es",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With the rollout of the `plugin_studio_migration` feature flag, the form edit view is now not embedded within the admin frontend anymore, but the experience studio instead.

As it seems, the language detection coming from this SDK was overwritten by the available languages in the frontend. Since the new Studio doesn't have that, it now actually uses this SDK's list of languages and can't resolve `en_GB`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://staffbasehq.slack.com/archives/C093GKLJ7B5/p1765449075066749

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- dev it
- create a form with enGB locale
- activate the `plugin_studio_migration` feature flag
- open that form
- should display correctly
- try to remove enGB and add it again
- should be available and work as intended

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** part in the readme.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Test plan:
<!--- Explain what has to be tested manually, to confirm the PR is ok -->