### PR TITLE
fix: upgrade lodash to 4.18.1 to patch CVE-2026-4800 (Dependabot #97)

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   },
   "resolutions": {
     "cross-spawn": "^7.0.6",
+    "lodash": "^4.18.0",
     "minimatch": "^5.1.8",
     "wrap-ansi": "^7.0.0",
     "semver": "^7.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4439,10 +4439,10 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@^4.17.15, lodash@^4.17.21, lodash@~4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@^4.17.15, lodash@^4.17.21, lodash@^4.18.0, lodash@~4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 loglevel@^1.8.1:
   version "1.9.2"


### PR DESCRIPTION
## Summary

- Adds `"lodash": "^4.18.0"` to the `resolutions` field in `package.json` to force all transitive dependents to use the patched version
- Resolves Dependabot alert [#97](https://github.com/Staffbase/plugins-client-sdk/security/dependabot/97)
- `yarn.lock` now pins lodash to **4.18.1**

## Security Advisory

**GHSA-r5fr-rjxr-66jc / CVE-2026-4800** — High severity  
`lodash` versions `>= 4.0.0, <= 4.17.23` are vulnerable to **Code Injection via `_.template` imports key names**. Untrusted input passed as `options.imports` key names flows into a `Function()` constructor sink, allowing arbitrary code execution at template compile time.

The fix (lodash 4.18.0+) validates `importsKeys` and replaces `assignInWith` with `assignWith` to avoid prototype pollution.

## Impact

`lodash` is a **transitive dev dependency** only — it is not shipped in the production bundle. Risk is limited to the build/test environment.

## Test plan

- [x] All 52 unit tests pass (`yarn test-unit`)
- [x] `yarn.lock` updated — lodash resolves to 4.18.1

🤖 Generated with [Claude Code](https://claude.ai/claude-code)