### PR TITLE
chore: upgrade code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @Staffbase/product-actions
+*   @Staffbase/product-central-tech

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @Staffbase/product-content-management
+*   @Staffbase/product-actions


### PR DESCRIPTION
## Context

Transferred code ownership to team-content-management accidentally yesterday. 

Now moving it to @Staffbase/product-central-tech which is hopefully correct.